### PR TITLE
[KAIZEN-0] laster flere secrets om de finnes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,17 @@
 
 # pus-fss-frontend
 Baseimage som server en statisk frontend bak innlogging
+
+## Bruk
+Imaget forventer miljøvariblene nedenfor;
+- ISSO_HOST_URL
+- ISSO_ISALIVE_URL
+- ISSO_ISSUER_URL
+- ISSO_JWKS_URL
+- OIDC_REDIRECT_URL
+- no.nav.modig.security.systemuser.username
+- no.nav.modig.security.systemuser.password
+- isso-rp-user.username
+- isso-rp-user.password 
+
+Om naiserator blir brukt så vil appen prøve å laste brukernavn og passord fra `service_user` og `isso-rp-user`.

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -30,7 +30,7 @@ public class Main {
 
     private static void loadSecret(String secretName, Consumer<NaisUtils.Credentials> consumer) {
         try {
-            consumer.accept(NaisUtils.getCredentials("service_user"));
+            consumer.accept(NaisUtils.getCredentials(secretName));
         } catch (Exception e) {
             log.warn(String.format("Kunne ikke laste inn secret: %s", secretName), e);
         }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,10 +1,13 @@
 import no.nav.apiapp.ApiApp;
+import no.nav.brukerdialog.security.Constants;
 import no.nav.common.nais.utils.NaisUtils;
 import no.nav.fssfrontend.ApplicationConfig;
 import no.nav.sbl.dialogarena.common.cxf.StsSecurityConstants;
 import no.nav.sbl.util.EnvironmentUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.function.Consumer;
 
 import static no.nav.sbl.util.EnvironmentUtils.Type.PUBLIC;
 import static no.nav.sbl.util.EnvironmentUtils.Type.SECRET;
@@ -13,18 +16,23 @@ public class Main {
     private static final Logger log = LoggerFactory.getLogger(Main.class);
 
     public static void main(String... args) throws Exception {
-        setupServiceUser();
+        loadSecret("service_user", (serviceUser) -> {
+            EnvironmentUtils.setProperty(StsSecurityConstants.SYSTEMUSER_USERNAME, serviceUser.username, PUBLIC);
+            EnvironmentUtils.setProperty(StsSecurityConstants.SYSTEMUSER_PASSWORD, serviceUser.password, SECRET);
+        });
+        loadSecret("isso-rp-user", (issoRPUser) -> {
+            EnvironmentUtils.setProperty(Constants.ISSO_RP_USER_USERNAME_PROPERTY_NAME, issoRPUser.username, PUBLIC);
+            EnvironmentUtils.setProperty(Constants.ISSO_RP_USER_PASSWORD_PROPERTY_NAME, issoRPUser.password, SECRET);
+        });
+
         ApiApp.runApp(ApplicationConfig.class, args);
     }
 
-    private static void setupServiceUser() {
+    private static void loadSecret(String secretName, Consumer<NaisUtils.Credentials> consumer) {
         try {
-            NaisUtils.Credentials serviceUser = NaisUtils.getCredentials("service_user");
-            EnvironmentUtils.setProperty(StsSecurityConstants.SYSTEMUSER_USERNAME, serviceUser.username, PUBLIC);
-            EnvironmentUtils.setProperty(StsSecurityConstants.SYSTEMUSER_PASSWORD, serviceUser.password, SECRET);
+            consumer.accept(NaisUtils.getCredentials("service_user"));
         } catch (Exception e) {
-            log.warn("Kunne ikke laste inn service bruker.", e);
+            log.warn(String.format("Kunne ikke laste inn secret: %s", secretName), e);
         }
     }
-
 }


### PR DESCRIPTION
I det alle er over på naiserator/vault oppsett så kan vi gjøre om slik at appen tryner hardt om en av secretene ikke finnes. Men beholder støtten for naisd enn så lenge.