### PR TITLE
Legger til mulighet for optional context-path environmentVariabel: APP_CONTEXT_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@ Baseimage som server en statisk frontend bak innlogging
 ## Bruk
 Webproxy må bli skrudd på for å nå login.microsoft.com.
 
-liveness: {APP_NAME}/internal/isAlive
-readiness: {APP_NAME}/internal/isReady
-prometheus: {APP_NAME}/internal/prometheus
-
 Imaget forventer miljøvariblene nedenfor:
 - NAIS_APP_NAME
 - OPENAM_DISCOVERY_URL
@@ -19,3 +15,14 @@ Imaget forventer miljøvariblene nedenfor:
 - VEILARBLOGIN_AAD_CLIENT_ID
 - VEILARBLOGIN_AAD_LOGIN_URL
 - UNLEASH_API_URL
+
+Optional miljøvariabler:
+- `APP_CONTEXT_PATH` - Om ikke satt benyttes `NAIS_APP_NAME` som context-path. 
+
+Internal-endepunkter:
+
+```
+liveness: {APP_CONTEXT_PATH}/internal/isAlive 
+readiness: {APP_CONTEXT_PATH}/internal/isReady 
+prometheus: {APP_CONTEXT_PATH}/internal/prometheus
+```  

--- a/src/main/java/no/nav/pus_fss_frontend/config/ApplicationConfig.java
+++ b/src/main/java/no/nav/pus_fss_frontend/config/ApplicationConfig.java
@@ -5,10 +5,14 @@ import no.nav.common.featuretoggle.UnleashServiceConfig;
 import no.nav.common.health.selftest.SelfTestChecks;
 import no.nav.common.health.selftest.SelfTestMeterBinder;
 import no.nav.pus_fss_frontend.filter.LoginRedirectFilter;
+import no.nav.pus_fss_frontend.utils.Utils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
 
 import java.util.Collections;
 
@@ -47,6 +51,21 @@ public class ApplicationConfig {
     @Bean
     public SelfTestMeterBinder selfTestMeterBinder(SelfTestChecks selfTestChecks) {
         return new SelfTestMeterBinder(selfTestChecks);
+    }
+
+    @Bean
+    public WebServerFactoryCustomizer<ConfigurableServletWebServerFactory> webServerFactoryCustomizer(EnvironmentProperties environmentProperties) {
+        return (factory) -> {
+            String contextPath = getContextPath(environmentProperties);
+            factory.setContextPath(contextPath);
+        };
+    }
+
+    static String getContextPath(EnvironmentProperties environmentProperties) {
+        String appContextPathEnv = environmentProperties.getContextPath();
+        String contextPath = !StringUtils.isEmpty(appContextPathEnv)? appContextPathEnv : environmentProperties.getNaisAppName();
+        if (StringUtils.isEmpty(contextPath)) return "";
+        return Utils.ensureStringIsPrefixed(contextPath, "/");
     }
 
 }

--- a/src/main/java/no/nav/pus_fss_frontend/config/EnvironmentProperties.java
+++ b/src/main/java/no/nav/pus_fss_frontend/config/EnvironmentProperties.java
@@ -25,4 +25,8 @@ public class EnvironmentProperties {
 
     private String unleashApiUrl;
 
+    private String naisAppName;
+
+    private String contextPath;
+
 }

--- a/src/main/java/no/nav/pus_fss_frontend/utils/Utils.java
+++ b/src/main/java/no/nav/pus_fss_frontend/utils/Utils.java
@@ -21,4 +21,9 @@ public class Utils {
 		return URLEncoder.encode(url, StandardCharsets.UTF_8);
 	}
 
+	public static String ensureStringIsPrefixed(String string, String prefix) {
+		if (string.startsWith(prefix)) return string;
+		return String.format("%s%s", prefix, string);
+	}
+
 }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,5 +1,3 @@
-server.servlet.context-path=/pus-fss-frontend
-
 management.endpoint.metrics.enabled=true
 management.endpoints.web.base-path=/internal
 management.endpoints.web.exposure.include=prometheus
@@ -15,3 +13,6 @@ app.env.aadVeilarbloginClientId=2edd96a2-fb5a-4dfa-8f36-848ae306f9b1
 app.env.aadVeilarbloginLoginUrl=https://app-q0.adeo.no/veilarblogin/api/aad-login
 
 app.env.unleashApiUrl=https://unleash.nais.adeo.no/api/
+
+app.env.naisAppName=${NAIS_APP_NAME:pus-fss-frontend}
+app.env.contextPath=${APP_CONTEXT_PATH:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 spring.main.banner-mode=off
-server.servlet.context-path=/${NAIS_APP_NAME}
 
 # Frontends som bruker dette imaget må putte filene sine under /app/public
 spring.resources.static-locations=file:/app/public
@@ -20,3 +19,6 @@ app.env.aadVeilarbloginClientId=${VEILARBLOGIN_AAD_CLIENT_ID}
 app.env.aadVeilarbloginLoginUrl=${VEILARBLOGIN_AAD_LOGIN_URL}
 
 app.env.unleashApiUrl=${UNLEASH_API_URL}
+
+app.env.naisAppName=${NAIS_APP_NAME:}
+app.env.contextPath=${APP_CONTEXT_PATH:}

--- a/src/test/java/no/nav/pus_fss_frontend/config/ApplicationConfigTest.java
+++ b/src/test/java/no/nav/pus_fss_frontend/config/ApplicationConfigTest.java
@@ -1,0 +1,52 @@
+package no.nav.pus_fss_frontend.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ApplicationConfigTest {
+
+    @Test
+    void getContextPath_shouldReturnEmpty_whenNaisAppNameAndContextPathIsNull() {
+        EnvironmentProperties environmentProperties = new EnvironmentProperties();
+        String contextPath = ApplicationConfig.getContextPath(environmentProperties);
+        assertEquals("", contextPath);
+    }
+
+    @Test
+    void getContextPath_shouldReturnEmpty_whenNaisAppNameIsEmpty() {
+        EnvironmentProperties environmentProperties = new EnvironmentProperties();
+        environmentProperties.setNaisAppName("");
+
+        String contextPath = ApplicationConfig.getContextPath(environmentProperties);
+        assertEquals("", contextPath);
+    }
+
+    @Test
+    void getContextPath_shouldReturnNaisAppName_whenNoContextPathIsSet() {
+        EnvironmentProperties environmentProperties = new EnvironmentProperties();
+        environmentProperties.setNaisAppName("/pus-fss-frontend");
+
+        String contextPath = ApplicationConfig.getContextPath(environmentProperties);
+        assertEquals("/pus-fss-frontend", contextPath);
+    }
+
+    @Test
+    void getContextPath_shouldReturnContextPath_whenOnlyContextPathIsSet() {
+        EnvironmentProperties environmentProperties = new EnvironmentProperties();
+        environmentProperties.setContextPath("annen/context-path");
+
+        String contextPath = ApplicationConfig.getContextPath(environmentProperties);
+        assertEquals("/annen/context-path", contextPath);
+    }
+
+    @Test
+    void getContextPath_shouldReturnContextPath_whenBothNaisAppNameAndContextPathIsSet() {
+        EnvironmentProperties environmentProperties = new EnvironmentProperties();
+        environmentProperties.setContextPath("/annen-context/path");
+        environmentProperties.setNaisAppName("/pus-fss-frontend");
+
+        String contextPath = ApplicationConfig.getContextPath(environmentProperties);
+        assertEquals("/annen-context/path", contextPath);
+    }
+}

--- a/src/test/java/no/nav/pus_fss_frontend/config/TestApplicationConfig.java
+++ b/src/test/java/no/nav/pus_fss_frontend/config/TestApplicationConfig.java
@@ -4,11 +4,15 @@ import no.nav.common.health.selftest.SelfTestChecks;
 import no.nav.common.health.selftest.SelfTestMeterBinder;
 import no.nav.pus_fss_frontend.controller.InternalController;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 import java.util.Collections;
+
+import static no.nav.pus_fss_frontend.config.ApplicationConfig.getContextPath;
 
 @Configuration
 @EnableConfigurationProperties({EnvironmentProperties.class})
@@ -41,6 +45,14 @@ public class TestApplicationConfig {
     @Bean
     public SelfTestMeterBinder selfTestMeterBinder(SelfTestChecks selfTestChecks) {
         return new SelfTestMeterBinder(selfTestChecks);
+    }
+
+    @Bean
+    public WebServerFactoryCustomizer<ConfigurableServletWebServerFactory> webServerFactoryCustomizer(EnvironmentProperties environmentProperties) {
+        return (factory) -> {
+            String contextPath = getContextPath(environmentProperties);
+            factory.setContextPath(contextPath);
+        };
     }
 
 }

--- a/src/test/java/no/nav/pus_fss_frontend/utils/UtilsTest.java
+++ b/src/test/java/no/nav/pus_fss_frontend/utils/UtilsTest.java
@@ -1,0 +1,20 @@
+package no.nav.pus_fss_frontend.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UtilsTest {
+
+    @Test
+    void ensureStringIsPrefixed() {
+        String prefixedContextPath1 = Utils.ensureStringIsPrefixed("context/path", "/");
+        String prefixedContextPath2 = Utils.ensureStringIsPrefixed("/context/path", "/");
+        String prefixedContextPath3 = Utils.ensureStringIsPrefixed("context-path", "/");
+        String prefixedContextPath4 = Utils.ensureStringIsPrefixed("/context-path", "/");
+        assertEquals("/context/path", prefixedContextPath1);
+        assertEquals("/context/path", prefixedContextPath2);
+        assertEquals("/context-path", prefixedContextPath3);
+        assertEquals("/context-path", prefixedContextPath4);
+    }
+}


### PR DESCRIPTION
Legger til mulighet for optional context-path environmentVariabel: APP_CONTEXT_PATH

* Fallback til NAIS_APP_NAME om den ikke er satt
* Om verken NAIS_APP_NAME eller APP_CONTEXT_PATH er satt blir context-pathen default tom.
* Legger de til i EnvironmentProperties slik at de kan brukes både i config og i tester.
* Passer på at context-path alltid starter med /
* Passer på at env. kan være null
* Oppdaterer readme
* Tester