### PR TITLE
[OPP-1218] legge til muligheten for å spesifisere csp-headere

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,20 @@ liveness: {APP_CONTEXT_PATH}/internal/isAlive
 readiness: {APP_CONTEXT_PATH}/internal/isReady 
 prometheus: {APP_CONTEXT_PATH}/internal/prometheus
 ```  
+
+## Konfigurasjon
+
+pus-fss-frontend sjekker om det finnes en `/config.yaml` så sant ikke noe annet er spesifisert 
+via miljøvariablen `CONFIGURATION_LOCATION`. 
+Hvis den ikke finner en konfigurasjonsfil eller noen av feltene er udefinerte, så vil pus-fss-frontend bruke en predefinert konfigurasjon.   
+Anbefalingen er derfor å bruke minimalistisk konfigurasjon.
+
+pus-fss-frontend er satt opp med interpolasjon av miljøvariabler, via `{{ ENV_VAR }}` syntaksen. 
+Dette gjøres av applikasjoner, og krever derfor at miljøvariablene er tilgjengelig ved kjøretid.
+
+- [Komplett eksempel på konfig kan ses her](https://github.com/navikt/pus-fss-frontend/blob/master/fss-frontend.example.yaml).
+- [Minimalt eksempel som skrur på CSP](https://github.com/navikt/pus-fss-frontend/blob/master/fss-frontend-minimal.example.yaml)
+
+
+For å bruke via docker trenger man bare å legge til følgende; 
+```ADD config.yaml /config.yaml```

--- a/fss-frontend-minimal.example.yaml
+++ b/fss-frontend-minimal.example.yaml
@@ -1,0 +1,8 @@
+# CSP rules
+csp:
+  mode: ENFORCE
+
+  # Default config if nothing else is specified.
+  # Browser will use `defaultSrc` as fallback for all other resource types when they don't have policies of their own
+  #defaultSrc: "'self'"
+  #reportUri: "/frontendlogger/api/warn"

--- a/fss-frontend.example.yaml
+++ b/fss-frontend.example.yaml
@@ -3,7 +3,7 @@ csp:
   # Default: NONE Values: ENFORCE, REPORT_ONLY or NONE
   mode: ENFORCE
   # Default: 'self'
-  defaultSrc: "'self' url.no url2.no"
+  defaultSrc: "'self' url-{{ENVIRONMENT_VARIABLE}}.no url2.no"
 
   # Default: null
   # Browser will use `defaultSrc` as fallback for all other resource types when they don't have policies of their own

--- a/fss-frontend.yaml
+++ b/fss-frontend.yaml
@@ -1,0 +1,18 @@
+# CSP rules
+csp:
+  # Default: NONE Values: ENFORCE, REPORT_ONLY or NONE
+  mode: ENFORCE
+  # Default: 'self'
+  defaultSrc: "'self' url.no url2.no"
+
+  # Default: null
+  # Browser will use `defaultSrc` as fallback for all other resource types when they don't have policies of their own
+  scriptSrc: "'self' 'unsafe-inline' url.no"
+  imgSrc: "'self' 'unsafe-inline' url.no"
+  styleSrc: "'self' 'unsafe-inline' url.no"
+  fontSrc: "'self' 'unsafe-inline' url.no"
+  connectSrc: "'self' 'unsafe-inline' url.no"
+  frameSrc: "'self' 'unsafe-inline' url.no"
+
+  # Default: /frontendlogger/api/warn
+  reportUri: "/frontendlogger/api/warn"

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,11 @@
             <artifactId>util</artifactId>
             <version>${common.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>no.nav.common</groupId>
+            <artifactId>yaml</artifactId>
+            <version>${common.version}</version>
+        </dependency>
         <dependency>
             <groupId>no.nav.common</groupId>
             <artifactId>auth</artifactId>
@@ -99,6 +103,12 @@
             <groupId>no.nav.common</groupId>
             <artifactId>health</artifactId>
             <version>${common.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.common</groupId>
+            <artifactId>test</artifactId>
+            <version>${common.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- test -->

--- a/src/main/java/no/nav/pus_fss_frontend/config/ApplicationConfig.java
+++ b/src/main/java/no/nav/pus_fss_frontend/config/ApplicationConfig.java
@@ -4,7 +4,9 @@ import no.nav.common.featuretoggle.UnleashService;
 import no.nav.common.featuretoggle.UnleashServiceConfig;
 import no.nav.common.health.selftest.SelfTestChecks;
 import no.nav.common.health.selftest.SelfTestMeterBinder;
-import no.nav.common.rest.filter.SetStandardHttpHeadersFilter;
+import no.nav.common.rest.filter.HttpFilterHeaders;
+import no.nav.common.rest.filter.SetHeaderFilter;
+import no.nav.pus_fss_frontend.config.yaml.YamlConfig;
 import no.nav.pus_fss_frontend.filter.LoginRedirectFilter;
 import no.nav.pus_fss_frontend.utils.Utils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -16,18 +18,25 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static java.util.Optional.ofNullable;
 import static no.nav.common.utils.EnvironmentUtils.requireApplicationName;
+import static no.nav.pus_fss_frontend.config.yaml.YamlConfigResolver.resolveConfig;
 
 @Configuration
 @EnableConfigurationProperties({EnvironmentProperties.class})
 public class ApplicationConfig {
+    private final YamlConfig config = resolveConfig();
 
     @Bean
-    public FilterRegistrationBean<SetStandardHttpHeadersFilter> setStandardHttpHeadersFilter() {
-        FilterRegistrationBean<SetStandardHttpHeadersFilter> registration = new FilterRegistrationBean<>();
-        registration.setFilter(new SetStandardHttpHeadersFilter());
+    public FilterRegistrationBean<SetHeaderFilter> setStandardHttpHeadersFilter() {
+        Map<String, String> headers = new HashMap<>(HttpFilterHeaders.STANDARD_HEADERS);
+        config.csp.applyTo(headers);
+
+        FilterRegistrationBean<SetHeaderFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(new SetHeaderFilter(headers));
         registration.setOrder(1);
         registration.addUrlPatterns("/*");
         return registration;

--- a/src/main/java/no/nav/pus_fss_frontend/config/yaml/CspConfig.java
+++ b/src/main/java/no/nav/pus_fss_frontend/config/yaml/CspConfig.java
@@ -1,0 +1,46 @@
+package no.nav.pus_fss_frontend.config.yaml;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.Map;
+
+@Data
+@Accessors(chain = true)
+public class CspConfig {
+    public CspMode mode = CspMode.NONE;
+    public String defaultSrc = "'self'";
+    public String scriptSrc;
+    public String imgSrc;
+    public String styleSrc;
+    public String fontSrc;
+    public String connectSrc;
+    public String frameSrc;
+    public String reportUri = "/frontendlogger/api/warn";
+
+
+    public void applyTo(Map<String, String> headers) {
+        if (mode.header != null) {
+            headers.put(mode.header, generateCspHeader());
+        }
+    }
+
+    String generateCspHeader() {
+        StringBuilder builder = new StringBuilder();
+        append(builder, "default-src", defaultSrc);
+        append(builder, "script-src", scriptSrc);
+        append(builder, "img-src", imgSrc);
+        append(builder, "style-src", styleSrc);
+        append(builder, "font-src", fontSrc);
+        append(builder, "connect-src", connectSrc);
+        append(builder, "frame-src", frameSrc);
+        append(builder, "report-uri", reportUri);
+        return builder.toString();
+    }
+
+    private static void append(StringBuilder builder, String directive, String value) {
+        if (value != null) {
+            builder.append(" " + directive + " " + value + ";");
+        }
+    }
+}

--- a/src/main/java/no/nav/pus_fss_frontend/config/yaml/CspMode.java
+++ b/src/main/java/no/nav/pus_fss_frontend/config/yaml/CspMode.java
@@ -1,0 +1,13 @@
+package no.nav.pus_fss_frontend.config.yaml;
+
+public enum CspMode {
+    ENFORCE("Content-Security-Policy"),
+    REPORT_ONLY("Content-Security-Policy-Report-Only"),
+    NONE(null);
+
+    public final String header;
+
+    CspMode(String header) {
+        this.header = header;
+    }
+}

--- a/src/main/java/no/nav/pus_fss_frontend/config/yaml/YamlConfig.java
+++ b/src/main/java/no/nav/pus_fss_frontend/config/yaml/YamlConfig.java
@@ -1,0 +1,10 @@
+package no.nav.pus_fss_frontend.config.yaml;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class YamlConfig {
+    public CspConfig csp = new CspConfig();
+}

--- a/src/main/java/no/nav/pus_fss_frontend/config/yaml/YamlConfigResolver.java
+++ b/src/main/java/no/nav/pus_fss_frontend/config/yaml/YamlConfigResolver.java
@@ -1,0 +1,47 @@
+package no.nav.pus_fss_frontend.config.yaml;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import no.nav.common.utils.EnvironmentUtils;
+import no.nav.common.utils.NaisUtils;
+import no.nav.common.yaml.YamlUtils;
+
+import java.io.File;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+public class YamlConfigResolver {
+
+    public static final String CONFIGURATION_LOCATION_PROPERTY = "CONFIGURATION_LOCATION";
+
+    public static YamlConfig resolveConfig() {
+        YamlConfig object = doResolveConfig();
+        log.info("{}", object);
+        return object;
+    }
+
+    @SneakyThrows
+    private static YamlConfig doResolveConfig() {
+        String configurationLocation = EnvironmentUtils.getOptionalProperty(CONFIGURATION_LOCATION_PROPERTY).orElse("/decorator.yaml");
+        File file = new File(configurationLocation);
+        if (file.exists()) {
+            log.info("Reading configuration file at: {}", configurationLocation);
+            return YamlUtils.fromYaml(interpolate(NaisUtils.getFileContent(file.getPath())), YamlConfig.class);
+        } else {
+            log.info("No configuration found at {}, using default configuration", configurationLocation);
+            return new YamlConfig();
+        }
+    }
+
+    static String interpolate(String string) {
+        StringBuffer sb = new StringBuffer();
+        Matcher matcher = Pattern.compile("\\{\\{(.+?)}}").matcher(string);
+        while (matcher.find()) {
+            String trim = matcher.group(1).trim();
+            matcher.appendReplacement(sb, EnvironmentUtils.getRequiredProperty(trim));
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+}

--- a/src/main/java/no/nav/pus_fss_frontend/config/yaml/YamlConfigResolver.java
+++ b/src/main/java/no/nav/pus_fss_frontend/config/yaml/YamlConfigResolver.java
@@ -23,7 +23,7 @@ public class YamlConfigResolver {
 
     @SneakyThrows
     private static YamlConfig doResolveConfig() {
-        String configurationLocation = EnvironmentUtils.getOptionalProperty(CONFIGURATION_LOCATION_PROPERTY).orElse("/decorator.yaml");
+        String configurationLocation = EnvironmentUtils.getOptionalProperty(CONFIGURATION_LOCATION_PROPERTY).orElse("/config.yaml");
         File file = new File(configurationLocation);
         if (file.exists()) {
             log.info("Reading configuration file at: {}", configurationLocation);

--- a/src/test/java/no/nav/pus_fss_frontend/config/yaml/CspConfigTest.java
+++ b/src/test/java/no/nav/pus_fss_frontend/config/yaml/CspConfigTest.java
@@ -1,0 +1,65 @@
+package no.nav.pus_fss_frontend.config.yaml;
+
+
+import lombok.SneakyThrows;
+import no.nav.common.test.junit.SystemPropertiesRule;
+import org.apache.commons.io.IOUtils;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.HashMap;
+
+import static no.nav.pus_fss_frontend.config.yaml.YamlConfigResolver.CONFIGURATION_LOCATION_PROPERTY;
+import static no.nav.pus_fss_frontend.config.yaml.YamlConfigResolver.resolveConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CspConfigTest {
+    @Rule
+    public SystemPropertiesRule systemPropertiesRule = new SystemPropertiesRule();
+
+    @Test
+    public void dontAddHeaderIfDisabled() {
+        HashMap<String, String> headers = new HashMap<>();
+        CspConfig config = new CspConfig();
+        config.applyTo(headers);
+
+        assertThat(headers).isEmpty();
+    }
+
+    @Test
+    public void addHeaderIfEabled() {
+        HashMap<String, String> headers = new HashMap<>();
+        CspConfig config = new CspConfig()
+                .setMode(CspMode.ENFORCE);
+        config.applyTo(headers);
+
+        assertThat(headers).hasSize(1);
+        assertThat(headers.get(CspMode.ENFORCE.header)).isEqualTo("" +
+                " default-src 'self';" +
+                " report-uri /frontendlogger/api/warn;"
+        );
+    }
+
+    @Test
+    public void generateCspHeader() {
+        systemPropertiesRule.setProperty(CONFIGURATION_LOCATION_PROPERTY, YamlConfigResolverTest.class.getResource("/config/rich.config.yaml").getFile());
+        YamlConfig config = resolveConfig();
+        assertThat(config.csp.generateCspHeader()).isEqualTo(""+
+                " default-src 'self' url.no;" +
+                " script-src 'self' 'unsafe-inline' 'unsafe-eval' url1.no *.url2.no;" +
+                " img-src 'self' url.no data:;" +
+                " style-src 'self' *.url.domain.no;" +
+                " font-src 'self' *.url.no;" +
+                " connect-src 'self' www.url.no;" +
+                " frame-src www.url.no;" +
+                " report-uri /frontendlogger/api/warn;"
+        );
+    }
+
+    @SneakyThrows
+    private String readResource(String name) {
+        InputStream resourceAsStream = YamlConfigResolverTest.class.getResourceAsStream(name);
+        return IOUtils.toString(resourceAsStream, "UTF-8");
+    }
+}

--- a/src/test/java/no/nav/pus_fss_frontend/config/yaml/YamlConfigResolverTest.java
+++ b/src/test/java/no/nav/pus_fss_frontend/config/yaml/YamlConfigResolverTest.java
@@ -1,0 +1,99 @@
+package no.nav.pus_fss_frontend.config.yaml;
+
+import lombok.SneakyThrows;
+import no.nav.common.test.junit.SystemPropertiesRule;
+import no.nav.common.yaml.YamlUtils;
+import org.apache.commons.io.IOUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import java.io.InputStream;
+
+import static no.nav.pus_fss_frontend.config.yaml.YamlConfigResolver.CONFIGURATION_LOCATION_PROPERTY;
+import static no.nav.pus_fss_frontend.config.yaml.YamlConfigResolver.resolveConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class YamlConfigResolverTest {
+    @Rule
+    public SystemPropertiesRule systemPropertiesRule = new SystemPropertiesRule();
+
+    @Test
+    public void emptyConfig() {
+        YamlConfig config = resolveConfig();
+        assertThat(config).isEqualTo(new YamlConfig()
+                .setCsp(new CspConfig()
+                        .setMode(CspMode.NONE)
+                        .setReportUri("/frontendlogger/api/warn")
+                )
+        );
+        assertThat(YamlUtils.toYaml(config)).isEqualTo(readResource("/config/default.config.yaml"));
+    }
+
+    @Test
+    public void enabledDefault() {
+        systemPropertiesRule.setProperty(CONFIGURATION_LOCATION_PROPERTY, YamlConfigResolverTest.class.getResource("/config/enable.config.yaml").getFile());
+        YamlConfig config = resolveConfig();
+        assertThat(config).isEqualTo(new YamlConfig()
+                .setCsp(new CspConfig()
+                        .setMode(CspMode.REPORT_ONLY)
+                        .setReportUri("/frontendlogger/api/warn")
+                )
+        );
+    }
+
+    @Test
+    public void interpolatedValues() {
+        systemPropertiesRule.setProperty(CONFIGURATION_LOCATION_PROPERTY, YamlConfigResolverTest.class.getResource("/config/interpolated.config.yaml").getFile());
+        systemPropertiesRule.setProperty("ENVIRONMENT", "q");
+
+        YamlConfig config = resolveConfig();
+        assertThat(config).isEqualTo(new YamlConfig()
+                .setCsp(new CspConfig()
+                        .setMode(CspMode.ENFORCE)
+                        .setScriptSrc("'self' app.url.no app-q.url.no")
+                        .setReportUri("/frontendlogger/api/warn")
+                )
+        );
+    }
+
+    @Test
+    public void richConfig() {
+        systemPropertiesRule.setProperty(CONFIGURATION_LOCATION_PROPERTY, YamlConfigResolverTest.class.getResource("/config/rich.config.yaml").getFile());
+        YamlConfig config = resolveConfig();
+
+        assertThat(config).isEqualTo(new YamlConfig()
+                .setCsp(new CspConfig()
+                        .setMode(CspMode.ENFORCE)
+                        .setDefaultSrc("'self' url.no")
+                        .setScriptSrc("'self' 'unsafe-inline' 'unsafe-eval' url1.no *.url2.no")
+                        .setImgSrc("'self' url.no data:")
+                        .setStyleSrc("'self' *.url.domain.no")
+                        .setFontSrc("'self' *.url.no")
+                        .setConnectSrc("'self' www.url.no")
+                        .setFrameSrc("www.url.no")
+                        .setReportUri("/frontendlogger/api/warn")
+                )
+        );
+    }
+
+    @Test
+    public void interpolate() {
+        systemPropertiesRule.setProperty("A","1");
+        systemPropertiesRule.setProperty("B","2");
+        systemPropertiesRule.setProperty("C","3");
+        systemPropertiesRule.setProperty("D","4");
+
+        assertThat(YamlConfigResolver.interpolate("a:{{ A }} b:{{B}} c:{{ C}} d:{{D }}")).isEqualTo("a:1 b:2 c:3 d:4");
+        assertThat(YamlConfigResolver.interpolate("{{ A }}{{B}}{{ C}}{{D }}")).isEqualTo("1234");
+        assertThat(YamlConfigResolver.interpolate("abcd")).isEqualTo("abcd");
+
+        assertThatThrownBy(() -> YamlConfigResolver.interpolate("{{ NOT_AVAILABLE_PROPERTY }}")).hasMessageContaining("NOT_AVAILABLE_PROPERTY");
+    }
+
+
+    @SneakyThrows
+    private String readResource(String name) {
+        InputStream resourceAsStream = YamlConfigResolverTest.class.getResourceAsStream(name);
+        return IOUtils.toString(resourceAsStream, "UTF-8");
+    }
+}

--- a/src/test/resources/config/default.config.yaml
+++ b/src/test/resources/config/default.config.yaml
@@ -1,0 +1,11 @@
+---
+csp:
+  mode: "NONE"
+  defaultSrc: "'self'"
+  scriptSrc: null
+  imgSrc: null
+  styleSrc: null
+  fontSrc: null
+  connectSrc: null
+  frameSrc: null
+  reportUri: "/frontendlogger/api/warn"

--- a/src/test/resources/config/enable.config.yaml
+++ b/src/test/resources/config/enable.config.yaml
@@ -1,0 +1,3 @@
+# CSP rules
+csp:
+  mode: REPORT_ONLY

--- a/src/test/resources/config/interpolated.config.yaml
+++ b/src/test/resources/config/interpolated.config.yaml
@@ -1,0 +1,4 @@
+# CSP rules
+csp:
+  mode: ENFORCE
+  scriptSrc: "'self' app.url.no app-{{ENVIRONMENT}}.url.no"

--- a/src/test/resources/config/rich.config.yaml
+++ b/src/test/resources/config/rich.config.yaml
@@ -1,0 +1,11 @@
+# CSP rules
+csp:
+  mode: ENFORCE
+  defaultSrc: "'self' url.no"
+  scriptSrc: "'self' 'unsafe-inline' 'unsafe-eval' url1.no *.url2.no"
+  imgSrc: "'self' url.no data:"
+  styleSrc: "'self' *.url.domain.no"
+  fontSrc: "'self' *.url.no"
+  connectSrc: "'self' www.url.no"
+  frameSrc: "www.url.no"
+  reportUri: "/frontendlogger/api/warn"


### PR DESCRIPTION
Vurderer å gjøre noe tilsvarende i pus-decorator, slik at det blir enklere å styre CSP fra hver enkelt app. 
Per i da så er CSP låst ned i pus-decorator og man kan kun styre om man ønsker at det skal enforces (noe ingen har skrudd på tror jeg).