### PR TITLE
[KAIZEN-0] forhindre redirect for å legge til trailing slash

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,6 +9,9 @@ management.endpoints.web.exposure.include=prometheus
 management.endpoint.prometheus.enabled=true
 management.metrics.export.prometheus.enabled=true
 
+# Forhindrer at man alltid får en redirect for å legge til slash
+server.tomcat.redirect-context-root=false
+
 # Application environment
 app.env.openAmDiscoveryUrl=${OPENAM_DISCOVERY_URL}
 app.env.openAmVeilarbloginClientId=${VEILARBLOGIN_OPENAM_CLIENT_ID}


### PR DESCRIPTION
Endrer slik at tomcat ikke alltid gjør en redirect om man går til `https://domain.com/contextpath`, per idag får man da en `302 Found http://domain.com/contextpath/`. Her er det noe krøll med protokollene så havner plutselig på `http`, dette blir dog fikset igjen når man får en `307 Redirect https://domain.com/contextpath/` 

Formålet med endringen er å unngå denne redirect-sløyfa, slik at appen kan svare direkte på `https://domain.com/contextpath`


Noen som greier å se noen negative side-effekter av å gjøre denne endringen?
